### PR TITLE
Fix example refs

### DIFF
--- a/lamps-rfc7030-csrattrs.mkd
+++ b/lamps-rfc7030-csrattrs.mkd
@@ -489,8 +489,8 @@ The CsrAttrs structure contains:
 
 ## Require a public key of a specific size
 
+(TODO remove: Example ref Harkins01)<br>
 The CSR requires an RSA public key of a specific size.
-<!--(Example harkins01)-->
 
 ### Base64 encoded example
 
@@ -511,8 +511,8 @@ Provide a CSR with an RSA key that's 4096 bits and use SHA256 as the hash algori
 
 ## Require a public key of a specific curve
 
+(TODO remove: Example ref Harkins02)<br>
 The CSR requires an ECC public key with a specific curve.
-<!--(Example harkins02)-->
 
 
 ### Base64 encoded example
@@ -535,10 +535,10 @@ use SHA384 as the hash algorithm within the signature.
 
 ## Require specific extensions and attributes
 
+(TODO remove: Example ref Harkins03)<br>
 The CSR is required to have an EC key, to include a serial number,
 a friendly name, favorite drink {{favoritedrink}} [OID 0.9.2342.19200300.100.1.5], and
 use SHA512 as the hash algorithm within the signature.
-<!--(Example harkins03)-->
 
 ### Base64 encoded example
 

--- a/lamps-rfc7030-csrattrs.mkd
+++ b/lamps-rfc7030-csrattrs.mkd
@@ -489,8 +489,8 @@ The CsrAttrs structure contains:
 
 ## Require a public key of a specific size
 
-The CSR requires a public key of a specific size
-(Example harkins01)
+The CSR requires an RSA public key of a specific size.
+<!--(Example harkins01)-->
 
 ### Base64 encoded example
 
@@ -511,8 +511,8 @@ Provide a CSR with an RSA key that's 4096 bits and use SHA256 as the hash algori
 
 ## Require a public key of a specific curve
 
-The CSR requires a public key with a specific curve.
-(Example harkins02)
+The CSR requires an ECC public key with a specific curve.
+<!--(Example harkins02)-->
 
 
 ### Base64 encoded example
@@ -538,7 +538,7 @@ use SHA384 as the hash algorithm within the signature.
 The CSR is required to have an EC key, to include a serial number,
 a friendly name, favorite drink {{favoritedrink}} [OID 0.9.2342.19200300.100.1.5], and
 use SHA512 as the hash algorithm within the signature.
-(Example harkins03)
+<!--(Example harkins03)-->
 
 ### Base64 encoded example
 

--- a/lamps-rfc7030-csrattrs.mkd
+++ b/lamps-rfc7030-csrattrs.mkd
@@ -209,10 +209,16 @@ MUST NOT include more than one element with a particular extnID.
 
 With this understanding, the needs of {{RFC8994}} and {{RFC8995}} are satisfied with no change to the bits on the wire.
 
-When not using the template-based approach of {#csrtemplate}, specifying the requirement for a public key of a specific type and optionally its size and other parameters MUST be done as follows:  Include exactly one Attribute with the `type` field being the OID specifying the type of the key, such as `ecPublicKey` or `rsaEncryption`.
+When not using the template-based approach of {{csrtemplate}},
+specifying the requirement for a public key of a specific type
+and optionally its size and other parameters MUST be done as follows:
+Include exactly one Attribute with the `type` field being the OID specifying
+the type of the key, such as `ecPublicKey` or `rsaEncryption`.
 The '`values`' field MAY be empty to indicate no further requirements on the key.
-Otherwise it MUST contain suitable parameters for the given key type, such as a singleton set containing the OID of an EC curve such as `secp384r1` or containing an integer value for the RSA key size such as 4096.
-Many examples for this are given in {#examples}
+Otherwise it MUST contain suitable parameters for the given key type,
+such as a singleton set containing the OID of an EC curve such as `secp384r1`
+or containing an integer value for the RSA key size such as 4096.
+Many examples for this are given in {{examples}}.
 
 ## Use of CSR templates {#csrtemplate}
 
@@ -377,7 +383,7 @@ will be as follows:
 # Co-existence with existing implementations
 
 Legacy servers MAY continue to use the {{RFC7030}}-style unstructured list of attribute/value pairs,
-and MAY also include the template style described in {#csrtemplate}.
+and MAY also include the template style described in {{csrtemplate}}.
 Clients which understand both MUST use the template only, and
 ignore all other CSRattrs elements.
 Older clients will ignore the new CertificationRequestInfoTemplate element.


### PR DESCRIPTION
On this occasion also re-formatted the new paragraph in section 3.2 for better diff'ing
and the intro of examples in 5.4, 5.5, and 5.6 (Harkins 01..03).